### PR TITLE
Modify the "sync_repo" function to use a release tarball download

### DIFF
--- a/libraries/kinesis_agent.rb
+++ b/libraries/kinesis_agent.rb
@@ -6,7 +6,7 @@ class KinesisAgent < Chef::Resource
 
   action :install do
     include_recipe 'apt'
-    package %w(git wget)
+    package 'tar'
 
     sync_repo(revision)
 
@@ -33,10 +33,12 @@ class KinesisAgent < Chef::Resource
     end
 
     def sync_repo(revision)
-      git "#{Chef::Config[:file_cache_path]}/amazon-kinesis-agent" do
-        repository 'https://github.com/awslabs/amazon-kinesis-agent.git'
-        revision revision
-        action :sync
+      remote_file "#{Chef::Config[:file_cache_path]}/amazon-kinesis-agent-#{revision}.tar.gz" do
+        source "https://github.com/awslabs/amazon-kinesis-agent/archive/#{revision}.tar.gz"
+      end
+      execute 'extract aws-kinesis-agent' do
+        cwd "#{Chef::Config[:file_cache_path]}"
+        command "tar -xvzf ./amazon-kinesis-agent-#{revision}.tar.gz"
       end
     end
 
@@ -44,7 +46,7 @@ class KinesisAgent < Chef::Resource
       cmd = "./setup --#{action}"
       cmd.prepend("JAVA_HOME=#{java_home} ") if java_home
       execute 'install aws-kinesis-agent' do
-        cwd "#{Chef::Config[:file_cache_path]}/amazon-kinesis-agent"
+        cwd "#{Chef::Config[:file_cache_path]}/amazon-kinesis-agent-#{revision}/"
         command cmd
       end
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'drugoradia@gmail.com'
 license 'Apache-2.0'
 description 'Installs/Configures aws-kinesis-agent'
 long_description 'Installs/Configures aws-kinesis-agent'
-version '0.3.2'
+version '0.3.3'
 
 chef_version '>= 12.5' if respond_to?(:chef_version)
 


### PR DESCRIPTION
This change remove the need of adding `git` to the node  in order to sync the repo content, it switches to use `remote_file` resource to download the release tarball directly.

I bumped the version number but i'm not sure it matches your versioning plan, but if desired I can add another commit that adjusts the version number.