### PR TITLE
Add checkpointFile property to aws_kinesis_config and fix its behavior to apply custom properties

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,6 @@ NumericLiteralPrefix:
   Enabled: false
 AbcSize:
   Enabled: false
+CyclomaticComplexity: 
+  Enabled: false
+  

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'drugoradia@gmail.com'
 license 'Apache-2.0'
 description 'Installs/Configures aws-kinesis-agent'
 long_description 'Installs/Configures aws-kinesis-agent'
-version '0.3.4'
+version '0.3.5'
 
 chef_version '>= 12.5' if respond_to?(:chef_version)
 

--- a/test/smoke/default/default_test.rb
+++ b/test/smoke/default/default_test.rb
@@ -23,6 +23,7 @@ end
   kinesis.endpoint
   cloudwatch.endpoint
   firehose.endpoint
+  checkpointFile
   flows
   /var/log/cloud-init-output.log
   /var/log/aws-kinesis-agent/aws-kinesis-agent.log


### PR DESCRIPTION
This change adds the property `checkpoint_file` giving the possibility to change its default path as defined here: https://github.com/awslabs/amazon-kinesis-agent/blob/807ed633f6b95245f058058278d7139221f5d7d8/src/com/amazon/kinesis/streaming/agent/config/AgentConfiguration.java#L27.

Additionally, it fixes few properties' behavior of the same resource since they were not supporting custom values.

I bumped the version number but i'm not sure it matches your versioning plan, but if desired I can add another commit that adjusts the version number.