### PR TITLE
added support for array of hashes data_processing_options

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'drugoradia@gmail.com'
 license 'Apache-2.0'
 description 'Installs/Configures aws-kinesis-agent'
 long_description 'Installs/Configures aws-kinesis-agent'
-version '0.3.4'
+version '0.3.5'
 
 chef_version '>= 12.5' if respond_to?(:chef_version)
 


### PR DESCRIPTION
This PR addresses issue #4 allow for an array of hashes in the data_processing_options property as supported by the aws client.